### PR TITLE
add kmesh tlv listener filter

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -40,6 +40,7 @@ envoy_cc_binary(
         "//source/extensions/filters/http/istio_stats",
         "//source/extensions/filters/http/peer_metadata:filter_lib",
         "//source/extensions/filters/network/metadata_exchange:config_lib",
+        "//source/extensions/filters/listener/kmesh_tlv:config",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )

--- a/source/extensions/filters/listener/kmesh_tlv/BUILD
+++ b/source/extensions/filters/listener/kmesh_tlv/BUILD
@@ -1,0 +1,38 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_binary",
+    "envoy_cc_library",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "kmesh_tlv_lib",
+    srcs = ["kmesh_tlv.cc"],
+    hdrs = ["kmesh_tlv.h"],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@envoy//envoy/buffer:buffer_interface",
+        "@envoy//envoy/network:filter_interface",
+        "@envoy//source/common/network:address_lib",
+        "@envoy//source/common/network:utility_lib",
+        "@envoy//source/common/network:filter_state_dst_address_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["kmesh_tlv_config_factory.cc"],
+    hdrs = ["kmesh_tlv_config_factory.h"],
+    repository = "@envoy",
+    deps = [
+        ":kmesh_tlv_lib",
+        "//source/extensions/filters/listener/kmesh_tlv/config:kmesh_tlv_cc_proto",
+        "@envoy//envoy/network:filter_interface",
+        "@envoy//envoy/registry:registry",
+        "@envoy//envoy/server:filter_config_interface",
+    ],
+)

--- a/source/extensions/filters/listener/kmesh_tlv/config/BUILD
+++ b/source/extensions/filters/listener/kmesh_tlv/config/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2019 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+proto_library(
+    name = "kmesh_tlv_proto",
+    srcs = ["kmesh_tlv.proto"],
+)
+
+cc_proto_library(
+    name = "kmesh_tlv_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = ["kmesh_tlv_proto"],
+)

--- a/source/extensions/filters/listener/kmesh_tlv/config/kmesh_tlv.proto
+++ b/source/extensions/filters/listener/kmesh_tlv/config/kmesh_tlv.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package envoy.listener.kmesh_tlv.config;
+
+option java_package = "io.envoyproxy.envoy.listener.kmesh_tlv.config";
+option java_outer_classname = "KmeshTlvProto";
+option java_multiple_files = true;
+option go_package = "KmeshTlv";
+
+// [#protodoc-title: Kmesh Tlv Filter]
+// Use to decode kmesh tlv protocol.
+// [#extension: envoy.filters.listener.kmesh_tlv]
+
+message KmeshTlv {
+}

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.cc
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.cc
@@ -1,0 +1,112 @@
+#include "kmesh_tlv.h"
+
+#include "source/common/network/address_impl.h"
+#include "source/common/network/utility.h"
+#include "source/common/network/filter_state_dst_address.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ListenerFilters {
+namespace KmeshTlv {
+
+Network::FilterStatus KmeshTlvFilter::onAccept(Network::ListenerFilterCallbacks& cb) {
+  ENVOY_LOG(trace, "kmesh_tlv: new connection accepted");
+  cb_ = &cb;
+  // Waiting for data.
+  return Network::FilterStatus::StopIteration;
+}
+
+Network::FilterStatus KmeshTlvFilter::onData(Network::ListenerFilterBuffer& buffer) {
+  const ReadOrParseState read_state = parseBuffer(buffer);
+  switch (read_state) {
+  case ReadOrParseState::Error:
+    cb_->socket().ioHandle().close();
+    return Network::FilterStatus::StopIteration;
+  case ReadOrParseState::TryAgainLater:
+    return Network::FilterStatus::StopIteration;
+  case ReadOrParseState::SkipFilter:
+    return Network::FilterStatus::Continue;
+  case ReadOrParseState::Done:
+    return Network::FilterStatus::Continue;
+  }
+  return Network::FilterStatus::Continue;
+}
+
+ReadOrParseState KmeshTlvFilter::parseBuffer(Network::ListenerFilterBuffer& buffer) {
+  ENVOY_LOG(trace, "kmesh tlv listener filter parse buffer");
+
+  auto raw_slice = buffer.rawSlice();
+  const uint8_t* buf = static_cast<const uint8_t*>(raw_slice.mem_);
+
+  while (raw_slice.len_ >= expected_length_) {
+    ENVOY_LOG(trace, "already has {} bytes in the buffer, expected length is {}", raw_slice.len_,
+              expected_length_);
+
+    switch (state_) {
+    case TlvParseState::TypeAndLength:
+      ENVOY_LOG(trace, "tlv parse state is TypeAndLength");
+
+      if (buf[index_] == TLV_TYPE_SERVICE) {
+        ENVOY_LOG(trace, "process TVL_TYPE_SERVICE");
+
+        uint32_t content_len = 0;
+        std::memcpy(&content_len, buf + index_ + 1, TLV_LENGTH_LEN);
+        content_len = ntohl(content_len);
+        ENVOY_LOG(trace, "get tlv length {}", content_len);
+
+        expected_length_ += content_len;
+        content_length_ = content_len;
+        index_ += (TLV_TYPE_LEN + TLV_LENGTH_LEN);
+        state_ = TlvParseState::Content;
+
+      } else if (buf[index_] == TLV_TYPE_ENDING) {
+        ENVOY_LOG(trace, "process TLV_TYPE_ENDING");
+
+        buffer.drain(expected_length_);
+
+        return ReadOrParseState::Done;
+      } else {
+        ENVOY_LOG(error, "invalid tlv type {}", buf[index_]);
+
+        return ReadOrParseState::Error;
+      }
+      break;
+
+    case TlvParseState::Content:
+      ENVOY_LOG(trace, "tlv parse state is Content");
+
+      sockaddr_storage addr;
+      int len;
+
+      addr.ss_family = AF_INET;
+      len = sizeof(struct sockaddr_in);
+      auto in4 = reinterpret_cast<struct sockaddr_in*>(&addr);
+      std::memcpy(&in4->sin_addr, buf + index_, 4);
+      uint16_t port = 0;
+      std::memcpy(&port, buf + index_ + 4, 2);
+      in4->sin_port = port;
+
+      std::string addrString =
+          (*Envoy::Network::Address::addressFromSockAddr(addr, len, false))->asString();
+
+      ENVOY_LOG(trace, "original dst addresss is {}", addrString);
+      const auto address = Network::Utility::parseInternetAddressAndPort(addrString);
+      cb_->filterState().setData(
+          "envoy.filters.listener.original_dst.local_ip",
+          std::make_shared<Network::AddressObject>(address),
+          StreamInfo::FilterState::StateType::Mutable,
+          StreamInfo::FilterState::LifeSpan::Connection,
+          StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce);
+      expected_length_ += (TLV_TYPE_LEN + TLV_LENGTH_LEN);
+      index_ += content_length_;
+      state_ = TlvParseState::TypeAndLength;
+    }
+  }
+
+  return ReadOrParseState::TryAgainLater;
+}
+
+} // namespace KmeshTlv
+} // namespace ListenerFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.cc
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.cc
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "kmesh_tlv.h"
 
 #include "source/common/network/address_impl.h"
@@ -53,6 +69,11 @@ ReadOrParseState KmeshTlvFilter::parseBuffer(Network::ListenerFilterBuffer& buff
         std::memcpy(&content_len, buf + index_ + 1, TLV_LENGTH_LEN);
         content_len = ntohl(content_len);
         ENVOY_LOG(trace, "get tlv length {}", content_len);
+
+        if (content_len < TLV_TYPE_SERVICE_MIN_CONTENT_LEN) {
+          ENVOY_LOG(error, "the content length of tlv type service should be at least {}",
+                    TLV_TYPE_SERVICE_MIN_CONTENT_LEN);
+        }
 
         expected_length_ += content_len;
         content_length_ = content_len;

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.h
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "envoy/network/filter.h"
+#include "envoy/stream_info/filter_state.h"
+
+#include "source/common/common/logger.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ListenerFilters {
+namespace KmeshTlv {
+
+enum class ReadOrParseState { Done, TryAgainLater, Error, SkipFilter };
+
+constexpr uint8_t TLV_TYPE_LEN = 0x1;
+constexpr uint8_t TLV_LENGTH_LEN = 0x4;
+constexpr uint8_t TLV_TYPE_SERVICE = 0x1;
+constexpr uint8_t TLV_TYPE_ENDING = 0xfe;
+constexpr uint8_t TLV_TYPE_EXTENSION = 0xff;
+
+enum TlvParseState { TypeAndLength = 0, Content = 1 };
+
+/**
+ * Implementation of a kmesh tlv listener filter.
+ */
+class KmeshTlvFilter : public Network::ListenerFilter, Logger::Loggable<Logger::Id::filter> {
+public:
+  // Network::ListenerFilter
+  Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override;
+
+  size_t maxReadBytes() const override { return max_kmesh_tlv_len_; }
+
+  Network::FilterStatus onData(Network::ListenerFilterBuffer&) override;
+
+private:
+  ReadOrParseState parseBuffer(Network::ListenerFilterBuffer& buffer);
+  // TODO: set max length properly.
+  static const size_t MAX_KMESH_TLV_LEN = 256;
+
+  Network::ListenerFilterCallbacks* cb_{};
+
+  TlvParseState state_{TypeAndLength};
+
+  uint32_t expected_length_{TLV_TYPE_LEN + TLV_LENGTH_LEN};
+
+  uint32_t index_{0};
+
+  uint32_t content_length_{0};
+
+  uint32_t max_kmesh_tlv_len_{MAX_KMESH_TLV_LEN};
+};
+
+} // namespace KmeshTlv
+} // namespace ListenerFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.h
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.h
@@ -28,10 +28,18 @@ namespace KmeshTlv {
 
 enum class ReadOrParseState { Done, TryAgainLater, Error, SkipFilter };
 
+// The length of tlv type field.
 constexpr uint8_t TLV_TYPE_LEN = 0x1;
+// The length of tlv length field.
 constexpr uint8_t TLV_LENGTH_LEN = 0x4;
+// If tlv type field is `0x1`, then this tlv
+// will include service address.
 constexpr uint8_t TLV_TYPE_SERVICE = 0x1;
+// If tlv type field is `0xfe`, then it is the last
+// tlv, after that will be payload data.
 constexpr uint8_t TLV_TYPE_ENDING = 0xfe;
+// If tvl type field is `0xff`, then this tlv will embed
+// many sub tlvs.
 constexpr uint8_t TLV_TYPE_EXTENSION = 0xff;
 // If tlv type is service, the min content length is 6
 // (ip addr is 4 bytes and port is 2 bytes).

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.h
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include "envoy/network/filter.h"
@@ -17,6 +33,9 @@ constexpr uint8_t TLV_LENGTH_LEN = 0x4;
 constexpr uint8_t TLV_TYPE_SERVICE = 0x1;
 constexpr uint8_t TLV_TYPE_ENDING = 0xfe;
 constexpr uint8_t TLV_TYPE_EXTENSION = 0xff;
+// If tlv type is service, the min content length is 6
+// (ip addr is 4 bytes and port is 2 bytes).
+constexpr uint8_t TLV_TYPE_SERVICE_MIN_CONTENT_LEN = 0x6;
 
 enum TlvParseState { TypeAndLength = 0, Content = 1 };
 

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.cc
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.cc
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "kmesh_tlv_config_factory.h"
 
 #include "envoy/registry/registry.h"

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.cc
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.cc
@@ -1,0 +1,32 @@
+#include "kmesh_tlv_config_factory.h"
+
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ListenerFilters {
+namespace KmeshTlv {
+
+Network::ListenerFilterFactoryCb KmeshTlvConfigFactory::createListenerFilterFactoryFromProto(
+    const Protobuf::Message&,
+    const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher,
+    Server::Configuration::ListenerFactoryContext&) {
+  return [listener_filter_matcher](Network::ListenerFilterManager& filter_manager) -> void {
+    filter_manager.addAcceptFilter(listener_filter_matcher, std::make_unique<KmeshTlvFilter>());
+  };
+}
+
+ProtobufTypes::MessagePtr KmeshTlvConfigFactory::createEmptyConfigProto() {
+  return std::make_unique<envoy::listener::kmesh_tlv::config::KmeshTlv>();
+}
+/**
+ * Static registration for the kmesh tlv filter. @see RegisterFactory.
+ */
+REGISTER_FACTORY(KmeshTlvConfigFactory, Server::Configuration::NamedListenerFilterConfigFactory){
+    "envoy.listener.kmesh_tlv"};
+
+} // namespace KmeshTlv
+} // namespace ListenerFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.h
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include "kmesh_tlv.h"

--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.h
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv_config_factory.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "kmesh_tlv.h"
+
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+#include "source/extensions/filters/listener/kmesh_tlv/config/kmesh_tlv.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ListenerFilters {
+namespace KmeshTlv {
+/**
+ * Config registration for the kmesh tlv filter.
+ */
+class KmeshTlvConfigFactory : public Server::Configuration::NamedListenerFilterConfigFactory {
+public:
+  // NamedListenerFilterConfigFactory
+  Network::ListenerFilterFactoryCb createListenerFilterFactoryFromProto(
+      const Protobuf::Message& message,
+      const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher,
+      Server::Configuration::ListenerFactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+
+  std::string name() const override { return "envoy.filters.listener.kmesh_tlv"; }
+};
+
+} // namespace KmeshTlv
+} // namespace ListenerFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
**What this PR does / why we need it**:

Add kmesh tlv listener filter which is used to decode metadata messages from connection.

In this PR, the kmesh tlv listener filter will only decode metadata about service address then provide basic L7 routing capability.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

part of: https://github.com/kmesh-net/kmesh/issues/135

**Special notes for your reviewer**:
