### PR TITLE
memset sockaddr

### DIFF
--- a/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.cc
+++ b/source/extensions/filters/listener/kmesh_tlv/kmesh_tlv.cc
@@ -103,17 +103,19 @@ ReadOrParseState KmeshTlvFilter::parseBuffer(Network::ListenerFilterBuffer& buff
       int len;
 
       if (content_length_ == TLV_TYPE_SERVICE_ADDRESS_IPV4_LEN) {
-        addr.ss_family = AF_INET;
         len = sizeof(struct sockaddr_in);
         auto in4 = reinterpret_cast<struct sockaddr_in*>(&addr);
+        std::memset(in4, 0, len);
+        addr.ss_family = AF_INET;
         std::memcpy(&in4->sin_addr, buf + index_, 4);
         uint16_t port = 0;
         std::memcpy(&port, buf + index_ + 4, 2);
         in4->sin_port = port;
       } else {
-        addr.ss_family = AF_INET6;
         len = sizeof(struct sockaddr_in6);
         auto in6 = reinterpret_cast<struct sockaddr_in6*>(&addr);
+        std::memset(in6, 0, len);
+        addr.ss_family = AF_INET6;
         std::memcpy(&in6->sin6_addr, buf + index_, 16);
         uint16_t port = 0;
         std::memcpy(&port, buf + index_ + 16, 2);


### PR DESCRIPTION
**What this PR does / why we need it**:

We should memset `sockaddr_in6` struct in ipv6 otherwise field like `sin6_scope_id` will be randomly assigned values, then the output address will contain unnecessary suffixes:

```bash
2024-08-09T09:42:23.930Z] "GET /reviews/0 HTTP/1.1" 200 - via_upstream - "-" 0 358 1019 1019 "-" "curl/8.9.1" "d950861d-b714-4d91-bdaf-9d6f3555702f" "reviews:9080" "[fd00:10:244:1::17]:9080" inbound-vip|9080|http|reviews.default.svc.cluster.local [fd00:10:244:1::1d]:60954 [fd00:10:96::559f%1444950607]:9080 envoy://internal_client_address/ - default
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
